### PR TITLE
Add ratio between buyback and reward for a given block

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17279,6 +17279,11 @@
       "integrity": "sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==",
       "dev": true
     },
+    "ts-treemap": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ts-treemap/-/ts-treemap-1.1.0.tgz",
+      "integrity": "sha512-0rWi12x7Y3vLG0bsgPZxeb/GClCcK0JE2L3O00VUhhxP8z+5rVBtUyeCdHcIUl8bEANdCT/D5bjKMW+CnfUZlw=="
+    },
     "tsconfig-paths": {
       "version": "3.9.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "rxjs": "~6.5.5",
     "sass-loader": "^10.0.1",
     "sockjs-client": "^1.5.0",
+    "ts-treemap": "^1.1.0",
     "tslib": "^2.0.0",
     "typescript": "~4.1.5",
     "zone.js": "~0.10.3"

--- a/src/app/chart/chart-general/chart-general.component.html
+++ b/src/app/chart/chart-general/chart-general.component.html
@@ -13,6 +13,7 @@
       <div class="title">
         {{title}}
       </div>
+      <p class="sub-title">Lines inside the chart have a non-comparable scale!</p>
       <div class="network-toggle">
         <div *ngIf="multipleNetworks">
           <span *ngFor="let n of networks">

--- a/src/app/chart/chart-general/chart-general.component.scss
+++ b/src/app/chart/chart-general/chart-general.component.scss
@@ -5,6 +5,13 @@
   text-align: center;
 }
 
+.sub-title {
+  font-size: 0.8em;
+  padding: 2px;
+  font-weight: bolder;
+  text-align: center;
+}
+
 .network-toggle {
   display: flex;
   justify-content: space-evenly;

--- a/src/app/dialogs/charts/farm-buybacks-dialog/farm-buybacks-dialog.component.ts
+++ b/src/app/dialogs/charts/farm-buybacks-dialog/farm-buybacks-dialog.component.ts
@@ -6,6 +6,7 @@ import {ChartGeneralMethodsComponent} from '../../../chart/chart-general-methods
 import {HardworksService} from '../../../services/http/hardworks.service';
 import {TvlsService} from '../../../services/http/tvls.service';
 import {PriceDataService} from '../../../services/data/price-data.service';
+import {RewardsService} from '../../../services/http/rewards.service'
 import {StaticValues} from '../../../static/static-values';
 import {Addresses} from '../../../static/addresses';
 import {RewardDataService} from '../../../services/data/reward-data.service';
@@ -24,21 +25,9 @@ export class FarmBuybacksDialogComponent extends ChartGeneralMethodsComponent im
               private hardworksService: HardworksService,
               private priceData: PriceDataService,
               private tvlsService: TvlsService,
-              private rewardService: RewardDataService,
+              private rewardService: RewardsService,
   ) {
     super(cdRef, vt);
-  }
-
-  private calcRewardComparison(address: string, network: string, buyBack: number): number {
-    // Calculate the ratio between the buyback and reward for a given block.
-    const reward =  this.rewardService.getReward(address, network);
-    if (buyBack !== 0 || reward !== 0){
-      if(buyBack > reward){
-        return buyBack / reward;
-      } else {
-        return reward / buyBack;
-      }
-    }
   }
 
   load(): void {
@@ -46,14 +35,24 @@ export class FarmBuybacksDialogComponent extends ChartGeneralMethodsComponent im
     forkJoin([
       this.hardworksService.getHardWorkHistoryData(StaticValues.NETWORKS.get(this.network)),
       this.tvlsService.getHistoryTvlByVault(Addresses.ADDRESSES.get('PS')),
-    ]).subscribe(([hardWorks, vaultData, ]) => {
+      this.rewardService.getHistoryRewards(Addresses.ADDRESSES.get('PS'), StaticValues.NETWORKS.get('eth')),
+    ]).subscribe(([hardWorks, vaultData, rewards]) => {
       this.log.debug('History of All Farm buybacks loaded ', hardWorks);
 
       const chartBuilder = new ChartBuilder();
-      chartBuilder.initVariables(3);
+      chartBuilder.initVariables(4);
+
+      const rewardArray = [];
+      let rewardsSum = 0;
+      rewards?.forEach(dto=>{
+        if(dto.isWeeklyReward){
+          rewardArray.push(dto.reward)
+          rewardArray.map(d=>rewardsSum+=d)
+          chartBuilder.addInData(2, dto.blockDate, rewardsSum);
+        }
+      })
 
       hardWorks?.forEach(dto => {
-        const rewardEmissionRatio = this.calcRewardComparison(dto.vaultAddress, dto.network, dto.farmBuyback);
         let bb = dto.farmBuybackSum / 1000;
         if (dto.network === 'bsc') {
           const farmPrice = this.priceData.getLastFarmPrice();
@@ -62,9 +61,11 @@ export class FarmBuybacksDialogComponent extends ChartGeneralMethodsComponent im
           } else {
             bb = 0;
           }
-        }
+      }
+        let rewardsBBRatio = bb/rewardsSum *100;
+
+        chartBuilder.addInData(3, dto.blockDate, rewardsBBRatio)
         chartBuilder.addInData(0, dto.blockDate, bb);
-        chartBuilder.addInData(2, dto.blockDate, rewardEmissionRatio);
       });
 
       this.log.debug('History of PS TVL loaded ', vaultData);
@@ -73,7 +74,8 @@ export class FarmBuybacksDialogComponent extends ChartGeneralMethodsComponent im
       this.handleData(chartBuilder, [
         ['FARM Buyback K', 'right', '#0085ff'],
         ['All supply K', '1', '#efa4a4'],
-        ['Comparison K', '2', '#28a69a']
+        ['Rewards K', '2', '#28a69a'],
+        ['Rewards to BB %', '3', 'red']
       ]);
     });
   }

--- a/src/app/services/http/rewards.service.ts
+++ b/src/app/services/http/rewards.service.ts
@@ -5,6 +5,7 @@ import {HttpService} from './http.service';
 import {WebsocketService} from '../websocket.service';
 import {WsConsumer} from '../ws-consumer';
 import {Network} from '../../models/network';
+import {StaticValues} from '../../static/static-values';
 
 @Injectable({
   providedIn: 'root'
@@ -65,6 +66,10 @@ export class RewardsService implements WsConsumer {
     endTimestamp = Math.floor(endTimestamp || (Date.now() / 1000));
     return this.httpService.httpGetWithNetwork(
         `/api/transactions/history/reward/?start=${startTimestamp}&end=${endTimestamp}`);
+  }
+
+  getAllHistoryRewardsByNetwork(network: Network = StaticValues.NETWORKS.get('eth')): Observable<RewardDto[]> {
+    return this.httpService.httpGet(`/api/transactions/history/reward`, network);
   }
 
 }


### PR DESCRIPTION
I believe I got the calculation you were looking for. I simply calculated the ratio between the buyback and the rewards that were expended. 

I had some issues with the chart scaling, since the y-axis are so far different. Once the user scrolls in though, you can see the variation in the ratio line. If you know of a way that I can make this present a little cleaner please let me know!